### PR TITLE
(draft) Suggestion from GP

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,15 @@ With the activation of the [Arithmetic Operation Cost Limit](https://github.com/
 
 Alternatively, this proposal could raise the limit to a higher constant value like `258`, the constant selected by Satoshi Nakamoto in [`reverted makefile.unix wx-config -- version 0.3.6`](https://gitlab.com/bitcoin-cash-node/bitcoin-cash-node/-/commit/757f0769d8360ea043f469f3a35f6ec204740446) (July 29, 2010). However, because the limit is no longer necessary for mitigating worst-case transaction validation cost, selection of any particular constant would be arbitrary.
 
-By fully-removing the limit, overall protocol complexity is reduced, simplifying both future VM implementations and contract development. For VM implementations, eliminating out-of-range cases significantly reduces the combinatorial set of possible inputs and outputs for the numeric operations: `OP_1ADD` (`0x8b`), `OP_1SUB` (`0x8c`), `OP_NEGATE` (`0x8f`), `OP_ABS` (`0x90`), `OP_NOT` (`0x91`), `OP_0NOTEQUAL` (`0x92`), `OP_ADD` (`0x93`), `OP_SUB` (`0x94`), `OP_MUL` (`0x95`), `OP_DIV` (`0x96`), `OP_MOD` (`0x97`), `OP_BOOLAND` (`0x9a`), `OP_BOOLOR` (`0x9b`), `OP_NUMEQUAL` (`0x9c`), `OP_NUMEQUALVERIFY` (`0x9d`), `OP_NUMNOTEQUAL` (`0x9e`), `OP_LESSTHAN` (`0x9f`), `OP_GREATERTHAN` (`0xa0`), `OP_LESSTHANOREQUAL` (`0xa1`), `OP_GREATERTHANOREQUAL` (`0xa2`), `OP_MIN` (`0xa3`), `OP_MAX` (`0xa4`), and `OP_WITHIN` (`0xa5`). For contract authors, eliminating the possibility of out-of-range errors prevents a class of potential vulnerabilities arising from a contract system's failure to validate that intermediate arithmetic results never exceed an (uncommonly-encountered) maximum number length limit.
+### Interaction with Existing Operations
+
+With one exception regarding overflow, the behavior of every operation remains unchanged. The overflow exception is described in [Removal of Overflow Behavior](#removal-of-overflow-behavior).
+
+The following list is the complete set of operations that interact with data on the stack with the assumption that the input(s) and/or output are VM numbers: `OP_NUM2BIN` (`0x80`), `OP_BIN2NUM` (`0x81`), `OP_1ADD` (`0x8b`), `OP_1SUB` (`0x8c`), `OP_NEGATE` (`0x8f`), `OP_ABS` (`0x90`), `OP_NOT` (`0x91`), `OP_0NOTEQUAL` (`0x92`), `OP_ADD` (`0x93`), `OP_SUB` (`0x94`), `OP_MUL` (`0x95`), `OP_DIV` (`0x96`), `OP_MOD` (`0x97`), `OP_BOOLAND` (`0x9a`), `OP_BOOLOR` (`0x9b`), `OP_NUMEQUAL` (`0x9c`), `OP_NUMEQUALVERIFY` (`0x9d`), `OP_NUMNOTEQUAL` (`0x9e`), `OP_LESSTHAN` (`0x9f`), `OP_GREATERTHAN` (`0xa0`), `OP_LESSTHANOREQUAL` (`0xa1`), `OP_GREATERTHANOREQUAL` (`0xa2`), `OP_MIN` (`0xa3`), `OP_MAX` (`0xa4`), and `OP_WITHIN` (`0xa5`).
+
+### Simplification of VM Implmentations and Contracts
+
+By fully-removing the limit, overall protocol complexity is reduced, simplifying both future VM implementations and contract development. For VM implementations, eliminating out-of-range cases significantly reduces the combinatorial set of possible inputs and outputs for the complete set of numeric operations listed in [Interaction with Existing Operations](#interaction-with-existing-operations). For contract authors, eliminating the possibility of out-of-range errors prevents a class of potential vulnerabilities arising from a contract system's failure to validate that intermediate arithmetic results never exceed an (uncommonly-encountered) maximum number length limit.
 
 ### Non-Inclusion of Implementation-Specific Technical Details
 
@@ -64,7 +72,11 @@ The software changes required to support this consensus change differ significan
 
 ### Non-Inclusion of VM Number Format or Operation Descriptions
 
-Beyond dropping the unnecessary limit on VM number length, this proposal does not modify any other properties of the VM. Notably, the precise format and behavior of VM numbers across all VM operations – especially `OP_1ADD` (`0x8b`), `OP_1SUB` (`0x8c`), `OP_NEGATE` (`0x8f`), `OP_ABS` (`0x90`), `OP_NOT` (`0x91`), `OP_0NOTEQUAL` (`0x92`), `OP_ADD` (`0x93`), `OP_SUB` (`0x94`), `OP_MUL` (`0x95`), `OP_DIV` (`0x96`), `OP_MOD` (`0x97`), `OP_BOOLAND` (`0x9a`), `OP_BOOLOR` (`0x9b`), `OP_NUMEQUAL` (`0x9c`), `OP_NUMEQUALVERIFY` (`0x9d`), `OP_NUMNOTEQUAL` (`0x9e`), `OP_LESSTHAN` (`0x9f`), `OP_GREATERTHAN` (`0xa0`), `OP_LESSTHANOREQUAL` (`0xa1`), `OP_GREATERTHANOREQUAL` (`0xa2`), `OP_MIN` (`0xa3`), `OP_MAX` (`0xa4`), and `OP_WITHIN` (`0xa5`) – are part of network consensus and do not otherwise change as a result of this proposal. For the avoidance of doubt, see the [Tests & Benchmarks](#tests--benchmarks).
+As described in [Interaction with Existing Operations](#interaction-with-existing-operations), this proposal does not modify any other properties of the VM. Notably, the precise format and behavior of VM numbers across all VM operations is part of network consensus and does not change as a result of this proposal. For the avoidance of doubt, see the [Tests & Benchmarks](#tests--benchmarks).
+
+### Removal of Overflow Behavior
+
+As a practical consequence of removing the limit, numerical operation overflow is no longer a meaningful concept. A number that becomes too large would be too large due to the cost system established in [`CHIP: Targeted Virtual Machine Limits`](https://github.com/bitjson/bch-vm-limits), not due to a numerical boundary. These operations previously required overflow considerations: `OP_1ADD` (`0x8b`), `OP_1SUB` (`0x8c`), `OP_ADD` (`0x93`), `OP_SUB` (`0x94`), `OP_MUL` (`0x95`).
 
 ## Stakeholder Responses & Statements
 

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,17 @@ As described in [Interaction with Existing Operations](#interaction-with-existin
 
 As a practical consequence of removing the limit, numerical operation overflow is no longer a meaningful concept. A number that becomes too large would be too large due to the cost system established in [`CHIP: Targeted Virtual Machine Limits`](https://github.com/bitjson/bch-vm-limits), not due to a numerical boundary. These operations previously required overflow considerations: `OP_1ADD` (`0x8b`), `OP_1SUB` (`0x8c`), `OP_ADD` (`0x93`), `OP_SUB` (`0x94`), `OP_MUL` (`0x95`).
 
+Example showing previous 64-bit integer overflow no longer overflows:
+
+- In the current VM, multiplication of two large 64-bit numbers using `OP_MUL` (`0x95`), where the result is too large to fit in the 64-bit number specification, will result in an overflow and therefore script failure. In other words, the two inputs are valid, but the output is too large.
+- In the VM upgraded with both this CHIP and the cost system of [`CHIP: Targeted Virtual Machine Limits`](https://github.com/bitjson/bch-vm-limits), the multiplication of the same two numbers no longer results in script failure per se. It might result in script failure if the overall cost of the transaction happens to be exceeded by this specific operation.
+
+Example showing removal of overflow behavior in general:
+
+- In the VM upgraded with both this CHIP and the cost system of [`CHIP: Targeted Virtual Machine Limits`](https://github.com/bitjson/bch-vm-limits), the maximum number is a 10,000 byte number, due to the cost system.
+- Multiplying two valid numbers that result in, for example, a 10,005 byte number would result in script failure due to the result being too large to push onto the stack.
+- Notably, the failure would not be due to an overflow of the number system.
+
 ## Stakeholder Responses & Statements
 
 [Stakeholder Responses & Statements &rarr;](stakeholders.md)


### PR DESCRIPTION
Please consider this PR as a suggestion from GP that replaces #4.

GP considers this PR plus some version of #2 and #3 to be the minimum update before considering this as a candidate for 2025 activation. To be clear, this is not an endorsement which will require review of the complete result.

The key points are:

1. Specific mention of interaction with all possible op codes. The current CHIP does not make the full set explicit, and does not make it crystal clear that there is no change of behavior. It almost does, but not quite.
2. Explicit mention of the change of overflow behavior, both for current overflows and what a reader might consider to be overflow (but is not) in the upgraded VM.
3. With respect to #4, after consideration, GP thinks that a complete specification of numerical ops will be fantastic to have, and would be best done in a separate context that will not potentially hold up this CHIP.